### PR TITLE
Fix Toast Context Implementation and Remove useToast Hook from Actions

### DIFF
--- a/src/components/forms/account-form.tsx
+++ b/src/components/forms/account-form.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, useWatch } from 'react-hook-form';
-import { useToast } from '~/components/alerts';
+import { toast } from '~/components/alerts';
 import { z } from 'zod';
 
 import { Button } from '~/components/buttons';
@@ -31,7 +31,6 @@ type AccountFormInputs = z.infer<typeof AccountSchema>;
 
 const AccountForm = () => {
   const { user, updateUserAttributes, loading } = useAuth();
-  const toast = useToast();
   const form = useForm<AccountFormInputs>({
     resolver: zodResolver(AccountSchema),
     defaultValues: {

--- a/src/components/forms/auth/login-form.tsx
+++ b/src/components/forms/auth/login-form.tsx
@@ -9,7 +9,7 @@ import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { z } from 'zod';
 
-import { ErrorAlert, useToast } from '~/components/alerts';
+import { ErrorAlert, toast } from '~/components/alerts';
 import { Button } from '~/components/buttons';
 import { Input } from '~/components/inputs';
 import { useAuth } from '~/hooks/useAuth';
@@ -35,7 +35,6 @@ const LoginSchema = z.object({
 type LoginFormInputs = z.infer<typeof LoginSchema>;
 
 const LoginForm = () => {
-  const toast = useToast();
   const errorAlertRef = useRef<HTMLDivElement>(null);
   const {
     signIn,

--- a/src/components/forms/auth/otp-validation-form.tsx
+++ b/src/components/forms/auth/otp-validation-form.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { ErrorAlert, useToast } from '~/components/alerts';
+import { ErrorAlert, toast } from '~/components/alerts';
 import { Button } from '~/components/buttons';
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '~/components/inputs';
 import { useAuth } from '~/hooks/useAuth';
@@ -36,7 +36,6 @@ const OTPValidationForm: React.FC<OTPValidationFormProps> = ({
   email,
   type,
 }) => {
-  const toast = useToast();
   const errorAlertRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const announcerRef = useRef<HTMLDivElement>(null);

--- a/src/components/forms/auth/signup-form.tsx
+++ b/src/components/forms/auth/signup-form.tsx
@@ -9,7 +9,7 @@ import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { z } from 'zod';
 
-import { ErrorAlert, useToast } from '~/components/alerts';
+import { ErrorAlert, toast } from '~/components/alerts';
 import { Button } from '~/components/buttons';
 import { Input } from '~/components/inputs';
 import { useAuth } from '~/hooks/useAuth';
@@ -41,7 +41,6 @@ const SignupSchema = z
 type SignupFormInputs = z.infer<typeof SignupSchema>;
 
 const SignupForm = () => {
-  const toast = useToast();
   const errorAlertRef = useRef<HTMLDivElement>(null);
   const {
     signUp,

--- a/src/components/layout/auth/auth-layout.tsx
+++ b/src/components/layout/auth/auth-layout.tsx
@@ -1,4 +1,4 @@
-import { Toasts } from '~/components/alerts/toast';
+import { Toasts } from '~/components/alerts';
 import { Announcer, AuthHeader, MaxWidthWrapper } from '..';
 
 const AuthLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (

--- a/src/components/layout/root-layout.tsx
+++ b/src/components/layout/root-layout.tsx
@@ -1,4 +1,4 @@
-import { Toasts } from '~/components/alerts/toast';
+import { Toasts } from '~/components/alerts';
 import { Announcer, Footer, Header, MaxWidthWrapper } from '.';
 
 const RootLayout: React.FC<{ children: React.ReactNode }> = ({ children }) => (

--- a/src/routes/protected/account.tsx
+++ b/src/routes/protected/account.tsx
@@ -1,6 +1,6 @@
 import { ExclamationTriangleIcon, PinRightIcon } from '@radix-ui/react-icons';
 import { useNavigate } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 
 import { Button } from '~/components/buttons';
 import { DangerDialog } from '~/components/dialogs';
@@ -11,7 +11,6 @@ import { useAuth } from '~/hooks/useAuth';
 const Account = () => {
   const { signOut, deleteUser } = useAuth();
   const navigate = useNavigate();
-  const toast = useToast();
 
   const handleDeleteAccount = async () => {
     try {

--- a/src/routes/protected/properties/add-property.tsx
+++ b/src/routes/protected/properties/add-property.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import { ActionFunctionArgs, redirect, useNavigate } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 
 import { Button } from '~/components/buttons';
 import { PropertyForm } from '~/components/forms';
@@ -16,7 +16,6 @@ import { addProperty } from '~/services';
 export const addPropertyAction =
   (queryClient: QueryClient) =>
     async ({ request }: ActionFunctionArgs) => {
-      const toast = useToast();
       try {
         const formData = await request.formData();
         const propertyName = formData.get('propertyName') as string;

--- a/src/routes/protected/properties/edit-property.tsx
+++ b/src/routes/protected/properties/edit-property.tsx
@@ -13,7 +13,7 @@ import {
   useLoaderData,
   useNavigate,
 } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 import { Button } from '~/components/buttons';
 import { DangerDialog } from '~/components/dialogs';
 import { PropertyForm } from '~/components/forms';
@@ -50,7 +50,6 @@ export const propertyLoader =
 export const updatePropertyAction =
   (queryClient: QueryClient) =>
     async ({ request, params }: ActionFunctionArgs) => {
-      const toast = useToast();
       assertNonNull(params.propertyId, 'No property ID provided');
 
       try {
@@ -87,7 +86,6 @@ export const updatePropertyAction =
 const EditProperty = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const toast = useToast();
   const { initialProperty, propertyId } = useLoaderData() as Awaited<
     ReturnType<ReturnType<typeof propertyLoader>>
   >;

--- a/src/routes/protected/reports/create-report.tsx
+++ b/src/routes/protected/reports/create-report.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import { ActionFunctionArgs, redirect, useActionData, useNavigate } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 
 import { Button } from '~/components/buttons';
 import { ReportForm } from '~/components/forms';
@@ -18,7 +18,6 @@ import { assertNonNull } from '~/utils/safety';
 export const createReportAction =
   (queryClient: QueryClient) =>
     async ({ request }: ActionFunctionArgs) => {
-      const toast = useToast();
       try {
         const formData = await request.formData();
         const reportName = formData.get('reportName');

--- a/src/routes/protected/reports/edit-report.tsx
+++ b/src/routes/protected/reports/edit-report.tsx
@@ -14,7 +14,7 @@ import {
   useLoaderData,
   useNavigate,
 } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 
 import { Button } from '~/components/buttons';
 import { DangerDialog } from '~/components/dialogs';
@@ -52,7 +52,6 @@ export const reportLoader =
 export const updateReportAction =
   (queryClient: QueryClient) =>
     async ({ params, request }: ActionFunctionArgs) => {
-      const toast = useToast();
       try {
         assertNonNull(params.reportId, 'reportId is required');
 
@@ -98,7 +97,6 @@ const EditReport = () => {
   >;
 
   const actionData = useActionData();
-  const toast = useToast();
 
   const [isFormChanged, setIsFormChanged] = useState(false);
   const selectedFilters = useStore((state) => state.selectedFilters);

--- a/src/routes/protected/reports/page-details.tsx
+++ b/src/routes/protected/reports/page-details.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { QueryClient, useQuery } from '@tanstack/react-query';
 import { ColumnDef } from '@tanstack/react-table';
 import { Link, LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
-import { useToast } from '~/components/alerts/toast';
+import { toast } from '~/components/alerts';
 
 import { Button } from '~/components/buttons';
 import Timeline from '~/components/charts/timeline';
@@ -53,7 +53,6 @@ const PageDetails = () => {
   });
 
   const [isSending, setIsSending] = useState(false);
-  const toast = useToast();
 
   if (error) return <div role="alert">Error loading page details.</div>;
 


### PR DESCRIPTION
This PR fixes the issue where the useToast hook was used inside an action, causing a failure since hooks can't be used outside components. I refactored the toast system by removing useToast from actions and using a ToastManager singleton to manage toasts globally.

**_Key Changes:_**

- Removed useToast from actions.
- Implemented ToastManager for global toast handling.
- Ensured proper toast display and sorting.

**_Bug Fix:_**

- Resolved 404 error caused by improper hook usage in actions.