### PR TITLE
Accessibility fixes for auth forms

### DIFF
--- a/src/components/forms/auth/login-form.tsx
+++ b/src/components/forms/auth/login-form.tsx
@@ -124,6 +124,7 @@ const LoginForm = () => {
                     type="email"
                     className="h-12 bg-white"
                     id="email"
+                    aria-required={true}
                     {...field}
                   />
                 </FormControl>
@@ -143,6 +144,7 @@ const LoginForm = () => {
                       type={showPassword ? 'text' : 'password'}
                       className="h-12 bg-white"
                       id="password"
+                      aria-required={true}
                       {...field}
                     />
                     <Button
@@ -173,13 +175,12 @@ const LoginForm = () => {
               className="h-12 w-full bg-[#1D781D] text-white"
               disabled={loading}
               aria-live="polite"
-              aria-label={loading ? 'Processing,please wait' : 'Continue'}
+              aria-label={loading ? 'Processing, please wait' : 'Continue'}
             >
               {loading ? (
                 <>
-                  <span className="sr-only">Processing, please wait...</span>
                   <div
-                    role="status"
+                    aria-hidden="true"
                     className="h-4 w-4 animate-spin rounded-full border-2 border-solid border-white border-t-transparent"
                   ></div>
                 </>

--- a/src/components/forms/auth/otp-validation-form.tsx
+++ b/src/components/forms/auth/otp-validation-form.tsx
@@ -79,13 +79,9 @@ const OTPValidationForm: React.FC<OTPValidationFormProps> = ({
         'Please enter the verification code sent to your email.';
     }
 
-    const timeoutId = setTimeout(() => {
       if (inputRef.current) {
         inputRef.current.focus();
       }
-    }, 5000);
-
-    return () => clearTimeout(timeoutId);
   }, []);
 
   const handleResendCode = useCallback(async () => {
@@ -166,7 +162,6 @@ const OTPValidationForm: React.FC<OTPValidationFormProps> = ({
             disabled={isCountingDown || loading}
             className="place-self-start bg-transparent p-0 text-gray-600 shadow-none"
             aria-live="polite"
-            aria-disabled={isCountingDown || loading}
             aria-label={
               isCountingDown ? `Resend in ${countdown}s` : 'Resend code'
             }
@@ -180,7 +175,7 @@ const OTPValidationForm: React.FC<OTPValidationFormProps> = ({
             aria-live="polite"
             aria-label={
               loading
-                ? 'Processing,please wait'
+                ? 'Processing, please wait'
                 : type === 'signup'
                   ? 'Verify and Sign Up'
                   : 'Verify and Log In'
@@ -188,9 +183,8 @@ const OTPValidationForm: React.FC<OTPValidationFormProps> = ({
           >
             {loading ? (
               <>
-                <span className="sr-only">Processing, please wait...</span>
                 <div
-                  role="status"
+                  aria-hidden="true"
                   className="h-4 w-4 animate-spin rounded-full border-2 border-solid border-white border-t-transparent"
                 ></div>
               </>

--- a/src/components/forms/auth/signup-form.tsx
+++ b/src/components/forms/auth/signup-form.tsx
@@ -128,6 +128,7 @@ const SignupForm = () => {
                       type="text"
                       className="h-12 bg-white"
                       id="firstName"
+                      aria-required={true}
                       {...field}
                     />
                   </FormControl>
@@ -147,6 +148,7 @@ const SignupForm = () => {
                       type="text"
                       className="h-12 bg-white"
                       id="lastName"
+                      aria-required={true}
                       {...field}
                     />
                   </FormControl>
@@ -167,6 +169,7 @@ const SignupForm = () => {
                     type="email"
                     className="h-12 bg-white"
                     id="email"
+                    aria-required={true}
                     {...field}
                   />
                 </FormControl>
@@ -187,6 +190,7 @@ const SignupForm = () => {
                       type={showPassword ? 'text' : 'password'}
                       className="h-12 bg-white"
                       id="password"
+                      aria-required={true}
                       {...field}
                     />
                     <Button
@@ -225,6 +229,7 @@ const SignupForm = () => {
                       type={showPassword ? 'text' : 'password'}
                       className="h-12 bg-white"
                       id="confirm-password"
+                      aria-required={true}
                       {...field}
                     />
                     <Button
@@ -257,13 +262,12 @@ const SignupForm = () => {
               className="h-12 w-full bg-[#1D781D] text-white"
               disabled={loading}
               aria-live="polite"
-              aria-label={loading ? 'Processing,please wait' : 'Continue'}
+              aria-label={loading ? 'Processing, please wait' : 'Continue'}
             >
               {loading ? (
                 <>
-                  <span className="sr-only">Processing, please wait...</span>
                   <div
-                    role="status"
+                    aria-hidden="true"
                     className="h-4 w-4 animate-spin rounded-full border-2 border-solid border-white border-t-transparent"
                   ></div>
                 </>

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -206,7 +206,6 @@ export const useAuth = () => {
   const signIn = useCallback(
     async ({ username, password }: SignInInput) => {
       setLoading(true);
-      return;
       try {
         const { isSignedIn, nextStep } = await authSignIn({
           username,

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -206,6 +206,7 @@ export const useAuth = () => {
   const signIn = useCallback(
     async ({ username, password }: SignInInput) => {
       setLoading(true);
+      return;
       try {
         const { isSignedIn, nextStep } = await authSignIn({
           username,

--- a/src/routes/public/auth/forgot.tsx
+++ b/src/routes/public/auth/forgot.tsx
@@ -47,7 +47,7 @@ const Forgot = () => {
                 <form onSubmit={forgotPassword} className='flex flex-col gap-8 w-full max-w-[448px]'>
                     <div className='flex flex-col gap-2'>
                         <label htmlFor='email' className='text-sm'>Email address</label>
-                        <input id='email' name='email' className='rounded-md p-3' />
+                        <input id='email' name='email' className='rounded-md p-3' aria-required={true} />
                     </div>
                     <button className='bg-[#1D781D] text-white rounded-md p-3 text-sm' type='submit'>Reset password</button>
                 </form>


### PR DESCRIPTION
- Apply `aria-required` to required fields. This helps with error prevention.
- Remove some redundant and invalid ARIA.
- Remove the focus delay on the OTP form. This can be a little jarring for users. Because the alert is assertive, that should announce before the newly focused input.