### PR TITLE
fix(a11y): increase toast timeout for WCAG 2.2.1 compliance

### DIFF
--- a/src/components/alerts/toast.tsx
+++ b/src/components/alerts/toast.tsx
@@ -146,13 +146,19 @@ export const Toasts: React.FC<{ children: React.ReactNode }> = ({ children }) =>
           [sortToasts],
         )}
       >
-        <ToastPrimitive.Provider swipeDirection="right">
+        <ToastPrimitive.Provider duration={10000} swipeDirection="right">
           {children}
           {Array.from(toasts).map(([key, toast]) => (
             <Toast
               key={key}
               id={key}
-              toast={toast}
+              toast={{
+                ...toast,
+                duration: Math.max(
+                  toast.duration || 10000,
+                  toast.status === 'error' ? 12000 : 10000
+                ),
+              }}
               onOpenChange={(open) => {
                 if (!open) {
                   toastElementsMapRef.current.delete(key);


### PR DESCRIPTION
This PR addresses issue [#463](https://github.com/EqualifyEverything/equalify/issues/463) by increasing the toast notification timeout to ensure adequate reading time for all users, including those with disabilities.

Changes:
- Set default toast duration to 10000ms (10 seconds)
- Extended error toast duration to 12000ms
- Ensured minimum duration enforcement for all toast types

These changes improve accessibility by:
- Giving users more time to read and process toast notifications
- Ensuring error messages have extra visibility time
- Maintaining WCAG 2.2.1 compliance for timed content

Future considerations (V2):
- I'm working on a new UI that will integrate persistent status banners at the page level
- I'm planning to implement inline feedback for form actions and critical updates